### PR TITLE
Fix handling of 0 available bots

### DIFF
--- a/concreep-redux/changelog.txt
+++ b/concreep-redux/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.3.1
+Date: 2024/04/07
+  Changes:
+    - Adjusted the lower bound on usable bots to zero, so that it won't place a single tile ghost if you have 0 bots in the network.
+  Known Issues:
+    - Space Exploration Compatability: When attempting to place space scaffolding, it will error once per tile, but the creep will progress. (Issue #1)
+    - Angels Bioprocessing Compatability: Attempting to place Bio Tiles near water will deadlock a ropobort's creep method. (Issue #10)
+
+---------------------------------------------------------------------------------------------------
 Version: 2.3.0
 Date: 2024/04/06
   Added:

--- a/concreep-redux/info.json
+++ b/concreep-redux/info.json
@@ -1,6 +1,6 @@
 {
   "name": "concreep-redux",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "Concreep Redux",
   "author": "Utoxin",
   "contact": "Github Issues",

--- a/concreep-redux/logic/creep_logic.lua
+++ b/concreep-redux/logic/creep_logic.lua
@@ -109,7 +109,7 @@ function creep(creeper)
 	-- This keeps any individual port from pulling too much of the network's bots towards it all at once, reducing bot travel/migration.
 
 	local working_bots    = total_bots - available_bots
-	local usable_robots   = math.max(1, math.ceil((((1 - idle_bot_percentage_setting) * total_bots) - working_bots) / active_port_factor))
+	local usable_robots   = math.max(0, math.ceil((((1 - idle_bot_percentage_setting) * total_bots) - working_bots) / active_port_factor))
 
 	creeper.usable_robots = usable_robots
 	if force.max_successful_attempts_per_tick_per_construction_queue * 60 < usable_robots then


### PR DESCRIPTION
Adjusts calculations of usable bots so that 0 is possible. This prevents it from placing a lone tile ghost when you have 0 bots in a network.

Closes #24 